### PR TITLE
Change status bar color of enemy units and buildings to a different color

### DIFF
--- a/signus-data/data/cs/texts/Makefile.am
+++ b/signus-data/data/cs/texts/Makefile.am
@@ -28,7 +28,8 @@ texts_src = brief1.txt brief10.txt brief11.txt brief12.txt brief13.txt \
 	txt60.txt txt61.txt txt62.txt txt63.txt txt64.txt txt65.txt txt66.txt \
 	txt67.txt txt68.txt txt69.txt txt7.txt txt70.txt txt71.txt txt73.txt \
 	txt74.txt txt75.txt txt76.txt txt77.txt txt78.txt txt79.txt txt8.txt \
-	txt80.txt txt81.txt txt82.txt txt83.txt txt84.txt txt9.txt udes1.txt \
+	txt80.txt txt81.txt txt82.txt txt83.txt txt84.txt txt85.txt txt9.txt \
+	udes1.txt \
 	udes10.txt udes11.txt udes12.txt udes13.txt udes14.txt udes15.txt \
 	udes16.txt udes17.txt udes18.txt udes19.txt udes2.txt udes20.txt \
 	udes21.txt udes22.txt udes23.txt udes24.txt udes25.txt udes26.txt \

--- a/signus-data/data/cs/texts/txt85.txt
+++ b/signus-data/data/cs/texts/txt85.txt
@@ -1,0 +1,1 @@
+Alternate enemy status bar colors

--- a/signus-data/data/en/texts/Makefile.am
+++ b/signus-data/data/en/texts/Makefile.am
@@ -28,7 +28,8 @@ texts_src = brief1.txt brief10.txt brief11.txt brief12.txt brief13.txt \
 	txt60.txt txt61.txt txt62.txt txt63.txt txt64.txt txt65.txt txt66.txt \
 	txt67.txt txt68.txt txt69.txt txt7.txt txt70.txt txt71.txt txt73.txt \
 	txt74.txt txt75.txt txt76.txt txt77.txt txt78.txt txt79.txt txt8.txt \
-	txt80.txt txt81.txt txt82.txt txt83.txt txt84.txt txt9.txt udes1.txt \
+	txt80.txt txt81.txt txt82.txt txt83.txt txt84.txt txt85.txt txt9.txt \
+	udes1.txt \
 	udes10.txt udes11.txt udes12.txt udes13.txt udes14.txt udes15.txt \
 	udes16.txt udes17.txt udes18.txt udes19.txt udes2.txt udes20.txt \
 	udes21.txt udes22.txt udes23.txt udes24.txt udes25.txt udes26.txt \

--- a/signus-data/data/en/texts/txt85.txt
+++ b/signus-data/data/en/texts/txt85.txt
@@ -1,0 +1,1 @@
+Alternate enemy status bar colors

--- a/signus/etc/default_signus.ini
+++ b/signus/etc/default_signus.ini
@@ -23,6 +23,7 @@ unit_move_rng          = 1 ;
 unit_shoot_rng         = 1 ;
 unit_visib_rng         = 0 ;
 stop_on_new_enemy      = 1 ;
+alt_enemy_status_color = 0 ;
 
 [game]
 fix_autofire_saturn    = 1 ;

--- a/signus/src/building.cpp
+++ b/signus/src/building.cpp
@@ -163,15 +163,21 @@ TSprite *TBuilding::GetStatusBar()
         s->data[s->w * 1 + i + 1] = s->data[s->w * 2 + i + 1] = 
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = 72; // dark green
     sz = 42 * HitPoints / MaxHitPoints;
-    if (sz < 12)
-        clr = 10; /*red*/
-    else
-    {
-        if (ID >= BADLIFE)
-            clr = 483; /*biege*/
-        else
+
+    if (iniAltEnemyStatusBarColors && ID >= BADLIFE) {
+        if (sz < 12) {
+            clr = 117; /*purple*/
+        } else {
+            clr = 227; /*biege*/
+        }
+    } else {
+        if (sz < 12) {
+            clr = 10; /*red*/
+        } else {
             clr = 59; /*light green*/
+        }
     }
+
     for (i = 0; i < sz; i++) 
         s->data[s->w * 1 + i + 1] = s->data[s->w * 2 + i + 1] = 
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = clr;

--- a/signus/src/building.cpp
+++ b/signus/src/building.cpp
@@ -165,17 +165,9 @@ TSprite *TBuilding::GetStatusBar()
     sz = 42 * HitPoints / MaxHitPoints;
 
     if (iniAltEnemyStatusBarColors && ID >= BADLIFE) {
-        if (sz < 12) {
-            clr = 117; /*purple*/
-        } else {
-            clr = 227; /*biege*/
-        }
+        clr = sz < 12 ? 156 /*orange*/ : 230; /*biege*/
     } else {
-        if (sz < 12) {
-            clr = 10; /*red*/
-        } else {
-            clr = 59; /*light green*/
-        }
+        clr = sz < 12 ? 10 /*red*/ : 59; /*light green*/
     }
 
     for (i = 0; i < sz; i++) 

--- a/signus/src/building.cpp
+++ b/signus/src/building.cpp
@@ -163,7 +163,15 @@ TSprite *TBuilding::GetStatusBar()
         s->data[s->w * 1 + i + 1] = s->data[s->w * 2 + i + 1] = 
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = 72; // dark green
     sz = 42 * HitPoints / MaxHitPoints;
-    if (sz < 12) clr = 10; /*red*/ else clr = 59; /*light green*/
+    if (sz < 12)
+        clr = 10; /*red*/
+    else
+    {
+        if (ID >= BADLIFE)
+            clr = 483; /*biege*/
+        else
+            clr = 59; /*light green*/
+    }
     for (i = 0; i < sz; i++) 
         s->data[s->w * 1 + i + 1] = s->data[s->w * 2 + i + 1] = 
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = clr;

--- a/signus/src/consts.h
+++ b/signus/src/consts.h
@@ -42,7 +42,7 @@
 
 
 // Konstanty textu (tlacitka, menu, hlasky) (pole SigText):
-#define TXT_COUNT            85
+#define TXT_COUNT            86
 
 #define TXT_ALWAYS            0
 #define TXT_READYSHOOT        1
@@ -128,7 +128,7 @@
 #define TXT_QOL_FEATURES     82
 #define TXT_FUEL_WARN_CBOX   83
 #define TXT_FUEL_WARN_MSG    84
-
+#define TXT_ALT_ENEMY_COLORS 85
 
 
 

--- a/signus/src/global.cpp
+++ b/signus/src/global.cpp
@@ -89,6 +89,8 @@ int iniMusicVol, iniSoundVol, iniSpeechVol;
 int iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange, iniShowShootRange,
     iniShowVisibRange, iniStopOnNewEnemy;
 
+int iniAltEnemyStatusBarColors;
+
 int iniJukeboxRandom, iniJukeboxRepeat, iniJukeboxListSize, iniJukeboxSave;
 
 int iniResolution;
@@ -268,6 +270,7 @@ bool LoadINI() {
 	iniShowShootRange = iniparser_getint(dict, "interface:unit_shoot_rng", 1);
 	iniShowVisibRange = iniparser_getint(dict, "interface:unit_visib_rng", 0);
 	iniStopOnNewEnemy = iniparser_getint(dict, "interface:stop_on_new_enemy", 1);
+	iniAltEnemyStatusBarColors = iniparser_getint(dict, "interface:alt_enemy_status_color", 0);
 
 	iniFixAutofireSaturn = iniparser_getint(dict, "game:fix_autofire_saturn", 1);
 	iniFixUnitStop = iniparser_getint(dict, "game:fix_unit_stop", 1);
@@ -317,10 +320,12 @@ void SaveINI() {
 		"unit_move_rng          = %i ;\n"
 		"unit_shoot_rng         = %i ;\n"
 		"unit_visib_rng         = %i ;\n"
-		"stop_on_new_enemy      = %i ;\n",
+		"stop_on_new_enemy      = %i ;\n"
+		"alt_enemy_status_color = %i ;\n",
 		iniAnimDelay, iniAnimDelay2, iniIdleDelay, iniScrollDelay,
 		iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange,
-		iniShowShootRange, iniShowVisibRange, iniStopOnNewEnemy);
+		iniShowShootRange, iniShowVisibRange, iniStopOnNewEnemy,
+		iniAltEnemyStatusBarColors);
 
 	fprintf(f, "\n[game]\n"
 		"fix_autofire_saturn    = %i ;\n"

--- a/signus/src/global.h
+++ b/signus/src/global.h
@@ -125,7 +125,7 @@ extern int iniMaximize;
 extern int iniMusicVol, iniSoundVol, iniSpeechVol;
 
 extern int iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange, iniShowShootRange,
-                 iniShowVisibRange, iniStopOnNewEnemy;
+                 iniShowVisibRange, iniStopOnNewEnemy, iniAltEnemyStatusBarColors;
 
 extern int iniJukeboxRepeat, iniJukeboxRandom, iniJukeboxListSize, iniJukeboxSave;
 extern int iniFixAutofireSaturn, iniFixUnitStop;

--- a/signus/src/signus.cpp
+++ b/signus/src/signus.cpp
@@ -31,6 +31,7 @@
 #include <time.h>
 #include <climits>
 #include <SDL_timer.h>
+#include <iostream>
 
 #include "mission_screen.h"
 #include "events.h"
@@ -396,6 +397,7 @@ void SetSoundVolume()
 void configure_features(void) {
 	int fix_autofire = iniFixAutofireSaturn, fix_ustop = iniFixUnitStop;
 	int warn_aircraft = iniWarnAircraftFuel;
+	int altEnemyColors = iniAltEnemyStatusBarColors;
 	TDialog dlg(9+(VIEW_SX-490)/2, 36+(VIEW_SY-300)/2, 490, 300, "dlgopti");
 
 	dlg.Insert(new TButton(340, 20, SigText[TXT_OK], cmOk, TRUE));
@@ -409,11 +411,14 @@ void configure_features(void) {
 	dlg.Insert(new TStaticText(10,86, 150,16, SigText[TXT_QOL_FEATURES]));
 	dlg.Insert(new TCheckBox(10, 108, 250, SigText[TXT_FUEL_WARN_CBOX],
 		&warn_aircraft));
+	dlg.Insert(new TCheckBox(10, 130, 250, SigText[TXT_ALT_ENEMY_COLORS],
+		&altEnemyColors));
 
 	if (dlg.Exec() == cmOk) {
 		iniFixAutofireSaturn = fix_autofire;
 		iniFixUnitStop = fix_ustop;
 		iniWarnAircraftFuel = warn_aircraft;
+		iniAltEnemyStatusBarColors = altEnemyColors;
 		ApplyINI();
 		SaveINI();
 	}

--- a/signus/src/signus.cpp
+++ b/signus/src/signus.cpp
@@ -480,6 +480,8 @@ void SetOptions() {
 		ApplyINI();
 	}
 
+	RedrawMap();
+
 	delete dlg;
 }
 

--- a/signus/src/signus.cpp
+++ b/signus/src/signus.cpp
@@ -31,7 +31,6 @@
 #include <time.h>
 #include <climits>
 #include <SDL_timer.h>
-#include <iostream>
 
 #include "mission_screen.h"
 #include "events.h"

--- a/signus/src/units.cpp
+++ b/signus/src/units.cpp
@@ -1149,15 +1149,20 @@ TSprite *TUnit::GetStatusBar()
     for (i = 0; i < 20; i++)
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = 72; // dark green
     sz = 20 * HitPoints / MaxHitPoints;
-    if (sz < 6)
-        clr = 10; /*red*/
-    else
-    {
-        if (ID >= BADLIFE)
-            clr = 483; /*biege*/
-        else
+    if (iniAltEnemyStatusBarColors && ID >= BADLIFE) {
+        if (sz < 6) {
+            clr = 117; /*purple*/
+        } else {
+            clr = 227; /*biege*/
+        }
+    } else {
+        if (sz < 6) {
+            clr = 10; /*red*/
+        } else {
             clr = 59; /*light green*/
+        }
     }
+
     for (i = 0; i < sz; i++) 
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = clr;
     sz = 20 * TimeUnits / MaxTimeUnits;

--- a/signus/src/units.cpp
+++ b/signus/src/units.cpp
@@ -1146,10 +1146,18 @@ TSprite *TUnit::GetStatusBar()
     s->w = 22, s->h = 6;
     s->dx = 11, s->dy = 15;
     
-    for (i = 0; i < 20; i++) 
+    for (i = 0; i < 20; i++)
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = 72; // dark green
     sz = 20 * HitPoints / MaxHitPoints;
-    if (sz < 6) clr = 10; /*red*/ else clr = 59; /*light green*/
+    if (sz < 6)
+        clr = 10; /*red*/
+    else
+    {
+        if (ID >= BADLIFE)
+            clr = 483; /*biege*/
+        else
+            clr = 59; /*light green*/
+    }
     for (i = 0; i < sz; i++) 
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = clr;
     sz = 20 * TimeUnits / MaxTimeUnits;

--- a/signus/src/units.cpp
+++ b/signus/src/units.cpp
@@ -1150,17 +1150,9 @@ TSprite *TUnit::GetStatusBar()
         s->data[s->w * 3 + i + 1] = s->data[s->w * 4 + i + 1] = 72; // dark green
     sz = 20 * HitPoints / MaxHitPoints;
     if (iniAltEnemyStatusBarColors && ID >= BADLIFE) {
-        if (sz < 6) {
-            clr = 117; /*purple*/
-        } else {
-            clr = 227; /*biege*/
-        }
+        clr = sz < 6 ? 156 /*orange*/ : 230; /*biege*/
     } else {
-        if (sz < 6) {
-            clr = 10; /*red*/
-        } else {
-            clr = 59; /*light green*/
-        }
+        clr = sz < 6 ? 10 /*red*/ : 59; /*light green*/
     }
 
     for (i = 0; i < sz; i++) 


### PR DESCRIPTION
Screenshot: https://imgur.com/a/9UWF86T

Currently, status bars for both the player and enemies are green, which can be difficult to differentiate and easy to confuse when units get mixed together.

It uses the color biege, which was randomly found because I couldn't find any documentation on how the color numbers were derived, but I actually think it works well as a color. I didn't choose red (10) only because it already indicates low health.