### PR TITLE
Add ini setting to skip intros

### DIFF
--- a/signus-data/data/cs/texts/Makefile.am
+++ b/signus-data/data/cs/texts/Makefile.am
@@ -28,8 +28,8 @@ texts_src = brief1.txt brief10.txt brief11.txt brief12.txt brief13.txt \
 	txt60.txt txt61.txt txt62.txt txt63.txt txt64.txt txt65.txt txt66.txt \
 	txt67.txt txt68.txt txt69.txt txt7.txt txt70.txt txt71.txt txt73.txt \
 	txt74.txt txt75.txt txt76.txt txt77.txt txt78.txt txt79.txt txt8.txt \
-	txt80.txt txt81.txt txt82.txt txt83.txt txt84.txt txt85.txt txt9.txt \
-	udes1.txt \
+	txt80.txt txt81.txt txt82.txt txt83.txt txt84.txt txt85.txt txt86.txt \
+	txt9.txt udes1.txt \
 	udes10.txt udes11.txt udes12.txt udes13.txt udes14.txt udes15.txt \
 	udes16.txt udes17.txt udes18.txt udes19.txt udes2.txt udes20.txt \
 	udes21.txt udes22.txt udes23.txt udes24.txt udes25.txt udes26.txt \

--- a/signus-data/data/cs/texts/txt86.txt
+++ b/signus-data/data/cs/texts/txt86.txt
@@ -1,0 +1,1 @@
+Play intro on startup

--- a/signus-data/data/en/texts/Makefile.am
+++ b/signus-data/data/en/texts/Makefile.am
@@ -28,8 +28,8 @@ texts_src = brief1.txt brief10.txt brief11.txt brief12.txt brief13.txt \
 	txt60.txt txt61.txt txt62.txt txt63.txt txt64.txt txt65.txt txt66.txt \
 	txt67.txt txt68.txt txt69.txt txt7.txt txt70.txt txt71.txt txt73.txt \
 	txt74.txt txt75.txt txt76.txt txt77.txt txt78.txt txt79.txt txt8.txt \
-	txt80.txt txt81.txt txt82.txt txt83.txt txt84.txt txt85.txt txt9.txt \
-	udes1.txt \
+	txt80.txt txt81.txt txt82.txt txt83.txt txt84.txt txt85.txt txt86.txt \
+	txt9.txt udes1.txt \
 	udes10.txt udes11.txt udes12.txt udes13.txt udes14.txt udes15.txt \
 	udes16.txt udes17.txt udes18.txt udes19.txt udes2.txt udes20.txt \
 	udes21.txt udes22.txt udes23.txt udes24.txt udes25.txt udes26.txt \

--- a/signus-data/data/en/texts/txt86.txt
+++ b/signus-data/data/en/texts/txt86.txt
@@ -1,0 +1,1 @@
+Play intro on startup

--- a/signus/etc/default_signus.ini
+++ b/signus/etc/default_signus.ini
@@ -24,7 +24,7 @@ unit_shoot_rng         = 1 ;
 unit_visib_rng         = 0 ;
 stop_on_new_enemy      = 1 ;
 alt_enemy_status_color = 0 ;
-skip_intros            = 0 ;
+play_intros            = 1 ;
 
 [game]
 fix_autofire_saturn    = 1 ;

--- a/signus/etc/default_signus.ini
+++ b/signus/etc/default_signus.ini
@@ -24,6 +24,7 @@ unit_shoot_rng         = 1 ;
 unit_visib_rng         = 0 ;
 stop_on_new_enemy      = 1 ;
 alt_enemy_status_color = 0 ;
+skip_intros            = 0 ;
 
 [game]
 fix_autofire_saturn    = 1 ;

--- a/signus/src/consts.h
+++ b/signus/src/consts.h
@@ -42,7 +42,7 @@
 
 
 // Konstanty textu (tlacitka, menu, hlasky) (pole SigText):
-#define TXT_COUNT            86
+#define TXT_COUNT            87
 
 #define TXT_ALWAYS            0
 #define TXT_READYSHOOT        1
@@ -129,6 +129,7 @@
 #define TXT_FUEL_WARN_CBOX   83
 #define TXT_FUEL_WARN_MSG    84
 #define TXT_ALT_ENEMY_COLORS 85
+#define TXT_PLAY_INTROS 86
 
 
 

--- a/signus/src/global.cpp
+++ b/signus/src/global.cpp
@@ -87,7 +87,7 @@ int iniScrollDelay, iniAnimDelay, iniAnimDelay2;
 int iniMusicVol, iniSoundVol, iniSpeechVol;
         
 int iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange, iniShowShootRange,
-    iniShowVisibRange, iniStopOnNewEnemy;
+    iniShowVisibRange, iniStopOnNewEnemy, iniSkipIntros;
 
 int iniAltEnemyStatusBarColors;
 
@@ -271,6 +271,7 @@ bool LoadINI() {
 	iniShowVisibRange = iniparser_getint(dict, "interface:unit_visib_rng", 0);
 	iniStopOnNewEnemy = iniparser_getint(dict, "interface:stop_on_new_enemy", 1);
 	iniAltEnemyStatusBarColors = iniparser_getint(dict, "interface:alt_enemy_status_color", 0);
+	iniSkipIntros = iniparser_getint(dict, "interface:skip_intros", 0);
 
 	iniFixAutofireSaturn = iniparser_getint(dict, "game:fix_autofire_saturn", 1);
 	iniFixUnitStop = iniparser_getint(dict, "game:fix_unit_stop", 1);
@@ -321,11 +322,12 @@ void SaveINI() {
 		"unit_shoot_rng         = %i ;\n"
 		"unit_visib_rng         = %i ;\n"
 		"stop_on_new_enemy      = %i ;\n"
-		"alt_enemy_status_color = %i ;\n",
+		"alt_enemy_status_color = %i ;\n"
+		"skip_intros            = %i ;\n",
 		iniAnimDelay, iniAnimDelay2, iniIdleDelay, iniScrollDelay,
 		iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange,
 		iniShowShootRange, iniShowVisibRange, iniStopOnNewEnemy,
-		iniAltEnemyStatusBarColors);
+		iniAltEnemyStatusBarColors, iniSkipIntros);
 
 	fprintf(f, "\n[game]\n"
 		"fix_autofire_saturn    = %i ;\n"

--- a/signus/src/global.cpp
+++ b/signus/src/global.cpp
@@ -87,7 +87,7 @@ int iniScrollDelay, iniAnimDelay, iniAnimDelay2;
 int iniMusicVol, iniSoundVol, iniSpeechVol;
         
 int iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange, iniShowShootRange,
-    iniShowVisibRange, iniStopOnNewEnemy, iniSkipIntros;
+    iniShowVisibRange, iniStopOnNewEnemy, iniPlayIntros;
 
 int iniAltEnemyStatusBarColors;
 
@@ -271,7 +271,7 @@ bool LoadINI() {
 	iniShowVisibRange = iniparser_getint(dict, "interface:unit_visib_rng", 0);
 	iniStopOnNewEnemy = iniparser_getint(dict, "interface:stop_on_new_enemy", 1);
 	iniAltEnemyStatusBarColors = iniparser_getint(dict, "interface:alt_enemy_status_color", 0);
-	iniSkipIntros = iniparser_getint(dict, "interface:skip_intros", 0);
+	iniPlayIntros = iniparser_getint(dict, "interface:play_intros", 1);
 
 	iniFixAutofireSaturn = iniparser_getint(dict, "game:fix_autofire_saturn", 1);
 	iniFixUnitStop = iniparser_getint(dict, "game:fix_unit_stop", 1);
@@ -323,11 +323,11 @@ void SaveINI() {
 		"unit_visib_rng         = %i ;\n"
 		"stop_on_new_enemy      = %i ;\n"
 		"alt_enemy_status_color = %i ;\n"
-		"skip_intros            = %i ;\n",
+		"play_intros            = %i ;\n",
 		iniAnimDelay, iniAnimDelay2, iniIdleDelay, iniScrollDelay,
 		iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange,
 		iniShowShootRange, iniShowVisibRange, iniStopOnNewEnemy,
-		iniAltEnemyStatusBarColors, iniSkipIntros);
+		iniAltEnemyStatusBarColors, iniPlayIntros);
 
 	fprintf(f, "\n[game]\n"
 		"fix_autofire_saturn    = %i ;\n"

--- a/signus/src/global.h
+++ b/signus/src/global.h
@@ -125,7 +125,8 @@ extern int iniMaximize;
 extern int iniMusicVol, iniSoundVol, iniSpeechVol;
 
 extern int iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange, iniShowShootRange,
-                 iniShowVisibRange, iniStopOnNewEnemy, iniAltEnemyStatusBarColors;
+                 iniShowVisibRange, iniStopOnNewEnemy, iniAltEnemyStatusBarColors,
+                 iniSkipIntros;
 
 extern int iniJukeboxRepeat, iniJukeboxRandom, iniJukeboxListSize, iniJukeboxSave;
 extern int iniFixAutofireSaturn, iniFixUnitStop;

--- a/signus/src/global.h
+++ b/signus/src/global.h
@@ -126,7 +126,7 @@ extern int iniMusicVol, iniSoundVol, iniSpeechVol;
 
 extern int iniEnhancedGuiOn, iniShowStatusbar, iniShowMoveRange, iniShowShootRange,
                  iniShowVisibRange, iniStopOnNewEnemy, iniAltEnemyStatusBarColors,
-                 iniSkipIntros;
+                 iniPlayIntros;
 
 extern int iniJukeboxRepeat, iniJukeboxRandom, iniJukeboxListSize, iniJukeboxSave;
 extern int iniFixAutofireSaturn, iniFixUnitStop;

--- a/signus/src/signus.cpp
+++ b/signus/src/signus.cpp
@@ -398,6 +398,7 @@ void configure_features(void) {
 	int fix_autofire = iniFixAutofireSaturn, fix_ustop = iniFixUnitStop;
 	int warn_aircraft = iniWarnAircraftFuel;
 	int altEnemyColors = iniAltEnemyStatusBarColors;
+	int playIntros = iniPlayIntros;
 	TDialog dlg(9+(VIEW_SX-490)/2, 36+(VIEW_SY-300)/2, 490, 300, "dlgopti");
 
 	dlg.Insert(new TButton(340, 20, SigText[TXT_OK], cmOk, TRUE));
@@ -413,12 +414,16 @@ void configure_features(void) {
 		&warn_aircraft));
 	dlg.Insert(new TCheckBox(10, 130, 250, SigText[TXT_ALT_ENEMY_COLORS],
 		&altEnemyColors));
+	dlg.Insert(new TCheckBox(10, 152, 250, SigText[TXT_PLAY_INTROS],
+		&playIntros));
 
 	if (dlg.Exec() == cmOk) {
 		iniFixAutofireSaturn = fix_autofire;
 		iniFixUnitStop = fix_ustop;
 		iniWarnAircraftFuel = warn_aircraft;
 		iniAltEnemyStatusBarColors = altEnemyColors;
+		iniPlayIntros = playIntros;
+
 		ApplyINI();
 		SaveINI();
 	}
@@ -1312,7 +1317,7 @@ void signus_main() {
 	int crash = CrashLoad();
 	int fs = TRUE;
 
-	if (!iniSkipIntros && !crash) {
+	if (iniPlayIntros && !crash) {
 		PlayAnimation("present2");
 		PlayAnimation("present1");
 		PlayAnimation("present3");

--- a/signus/src/signus.cpp
+++ b/signus/src/signus.cpp
@@ -1312,7 +1312,7 @@ void signus_main() {
 	int crash = CrashLoad();
 	int fs = TRUE;
 
-	if (!crash) {
+	if (!iniSkipIntros && !crash) {
 		PlayAnimation("present2");
 		PlayAnimation("present1");
 		PlayAnimation("present3");

--- a/signus/src/signus.cpp
+++ b/signus/src/signus.cpp
@@ -398,7 +398,7 @@ void configure_features(void) {
 	int fix_autofire = iniFixAutofireSaturn, fix_ustop = iniFixUnitStop;
 	int warn_aircraft = iniWarnAircraftFuel;
 	int altEnemyColors = iniAltEnemyStatusBarColors;
-	int playIntros = iniPlayIntros;
+
 	TDialog dlg(9+(VIEW_SX-490)/2, 36+(VIEW_SY-300)/2, 490, 300, "dlgopti");
 
 	dlg.Insert(new TButton(340, 20, SigText[TXT_OK], cmOk, TRUE));
@@ -414,15 +414,12 @@ void configure_features(void) {
 		&warn_aircraft));
 	dlg.Insert(new TCheckBox(10, 130, 250, SigText[TXT_ALT_ENEMY_COLORS],
 		&altEnemyColors));
-	dlg.Insert(new TCheckBox(10, 152, 250, SigText[TXT_PLAY_INTROS],
-		&playIntros));
 
 	if (dlg.Exec() == cmOk) {
 		iniFixAutofireSaturn = fix_autofire;
 		iniFixUnitStop = fix_ustop;
 		iniWarnAircraftFuel = warn_aircraft;
 		iniAltEnemyStatusBarColors = altEnemyColors;
-		iniPlayIntros = playIntros;
 
 		ApplyINI();
 		SaveINI();
@@ -434,6 +431,7 @@ void SetOptions() {
 	int _EnhancedGuiOn = iniEnhancedGuiOn, _SOE = iniStopOnNewEnemy;
 	int _fullscreen = iniFullscreen, _IdleD = 60 - iniIdleDelay;
 	int _ScrollD = 200 - iniScrollDelay, _AnimD = 200 - iniAnimDelay;
+	int _playIntros = iniPlayIntros;
 	int _AnimD2 = 200 - iniAnimDelay2;
 	int ret;
 
@@ -449,9 +447,11 @@ void SetOptions() {
 	dlg->Insert(new TBarGauge(10, 146, 310, 20, &_AnimD2, 200));
 	dlg->Insert(new TCheckBox(10, 175, 250, SigText[TXT_FULLSCREEN],
 		&_fullscreen));
-	dlg->Insert(new TCheckBox(10, 195, 250, SigText[TXT_ENABLE_GUI],
+	dlg->Insert(new TCheckBox(10, 195, 250, SigText[TXT_PLAY_INTROS],
+		&_playIntros));
+	dlg->Insert(new TCheckBox(10, 215, 250, SigText[TXT_ENABLE_GUI],
 		&_EnhancedGuiOn));
-	dlg->Insert(new TCheckBox(10, 215, 250, SigText[TXT_STOP_ON_ENEMY],
+	dlg->Insert(new TCheckBox(10, 235, 250, SigText[TXT_STOP_ON_ENEMY],
 		&_SOE));
 	dlg->Insert(new TButton(340, 20, SigText[TXT_OK], cmOk, TRUE));
 	dlg->Insert(new TButton(340, 60, SigText[TXT_CANCEL], cmCancel));
@@ -473,6 +473,7 @@ void SetOptions() {
 		iniScrollDelay = 200 - _ScrollD;
 		iniAnimDelay = 200 - _AnimD;
 		iniAnimDelay2 = 200 - _AnimD2;
+		iniPlayIntros = _playIntros;
 
 		if (_fullscreen != iniFullscreen) {
 			ToggleFullscreen();


### PR DESCRIPTION
For players wanting to skip the intros entirely, they can set "skip_intros" in the .ini file to '1'.